### PR TITLE
Disable Quarkus banner to reduce confusion with app under test

### DIFF
--- a/cli/src/main/resources/application.properties
+++ b/cli/src/main/resources/application.properties
@@ -5,3 +5,5 @@ quarkus.datasource.jdbc.max-size=1
 
 power-server.db.backup.period=5m
 power-server.db.backup.location=${HOME}/.power-server/db.sqlite
+
+quarkus.banner.enabled=false


### PR DESCRIPTION
When I was using this recently I got confused by the Quarkus banner on a Spring app. There's perhaps an argument to be made for suppressing more output, but I think suppressing the banner is low-risk.