### PR TITLE
chore: release 0.2.2.1

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: power-server
 release:
-  current-version: 0.2.2
+  current-version: 0.2.2.1
   next-version: 0.2.3-SNAPSHOT


### PR DESCRIPTION
This release is meant to ease testing quarkus-power while it's
being updated for changes in the backend.
